### PR TITLE
Fix LogisticRegression and ConvNet data loading

### DIFF
--- a/hpolib/benchmarks/ml/conv_net.py
+++ b/hpolib/benchmarks/ml/conv_net.py
@@ -21,7 +21,7 @@ class ConvolutionalNeuralNetwork(AbstractBenchmark):
     """
     def __init__(self, path=None, max_num_epochs=40, rng=None):
 
-        self.train, self.train_targets, self.valid, self.valid_targets, self.test, self.test_targets = self.get_data(path)
+        self.train, self.train_targets, self.valid, self.valid_targets, self.test, self.test_targets = self.get_data()
         self.max_num_epochs = max_num_epochs
         self.num_classes = len(np.unique(self.train_targets))
 
@@ -33,8 +33,8 @@ class ConvolutionalNeuralNetwork(AbstractBenchmark):
         lasagne.random.set_rng(self.rng)
         super(ConvolutionalNeuralNetwork, self).__init__()
 
-    def get_data(self, path):
-        pass
+    def get_data(self):
+        raise NotImplementedError()
 
     @AbstractBenchmark._check_configuration
     @AbstractBenchmark._configuration_as_array

--- a/hpolib/benchmarks/ml/logistic_regression.py
+++ b/hpolib/benchmarks/ml/logistic_regression.py
@@ -5,7 +5,7 @@ import theano
 import theano.tensor as T
 
 from hpolib.abstract_benchmark import AbstractBenchmark
-from hpolib.util.data_manager import DataManager
+from hpolib.util.data_manager import MNISTData
 import ConfigSpace as CS
 
 
@@ -19,7 +19,7 @@ class LogisticRegression(AbstractBenchmark):
     """
 
     def __init__(self, path=None, rng=None):
-        self.train, self.train_targets, self.valid, self.valid_targets, self.test, self.test_targets = self.get_data(path)
+        self.train, self.train_targets, self.valid, self.valid_targets, self.test, self.test_targets = self.get_data()
         self.num_epochs = 100
 
         # Use 10 time the number of classes as lower bound for the dataset fraction
@@ -35,7 +35,7 @@ class LogisticRegression(AbstractBenchmark):
 
         super(LogisticRegression, self).__init__()
 
-    def get_data(self, path):
+    def get_data(self):
         pass
 
     @AbstractBenchmark._check_configuration
@@ -214,7 +214,7 @@ class LogisticRegression(AbstractBenchmark):
 class LogisticRegressionOnMnist(LogisticRegression):
 
     def get_data(self):
-        dm = DataManager.MNISTData()
+        dm = MNISTData()
         return dm.load()
 
     @staticmethod

--- a/hpolib/benchmarks/ml/svm_benchmark.py
+++ b/hpolib/benchmarks/ml/svm_benchmark.py
@@ -75,7 +75,7 @@ class SupportVectorMachine(AbstractBenchmark):
         c = time.time() - start_time
 
         return {'function_value': y, "cost": c}
-    
+
     @AbstractBenchmark._check_configuration
     @AbstractBenchmark._configuration_as_array
     def objective_function_test(self, x, **kwargs):


### PR DESCRIPTION
Loading the LogisticRegression and ConvNets benchmarks breaks on master. This fixes it such that it no longer breaks.