### PR TITLE
Openml datamanager

### DIFF
--- a/hpolib/util/openml_data_manager.py
+++ b/hpolib/util/openml_data_manager.py
@@ -12,24 +12,12 @@ from hpolib.util.data_manager import HoldoutDataManager, \
 
 def _load_data(task_id):
     task = openml.tasks.get_task(task_id)
-
-    try:
-        task.get_train_test_split_indices(fold=0, repeat=1)
-        raise_exception = True
-    except:
-        raise_exception = False
-
-    if raise_exception:
+	
+	if task.estimation_procedure['parameters']['number_repeats'] > 1:
         raise ValueError('Task %d has more than one repeat. This benchmark '
                          'can only work with a single repeat.' % task_id)
 
-    try:
-        task.get_train_test_split_indices(fold=1, repeat=0)
-        raise_exception = True
-    except:
-        raise_exception = False
-
-    if raise_exception:
+    if task.estimation_procedure['parameters']['number_folds'] > 1:
         raise ValueError('Task %d has more than one fold. This benchmark '
                          'can only work with a single fold.' % task_id)
 

--- a/hpolib/util/openml_data_manager.py
+++ b/hpolib/util/openml_data_manager.py
@@ -12,8 +12,8 @@ from hpolib.util.data_manager import HoldoutDataManager, \
 
 def _load_data(task_id):
     task = openml.tasks.get_task(task_id)
-	
-	if task.estimation_procedure['parameters']['number_repeats'] > 1:
+    
+    if task.estimation_procedure['parameters']['number_repeats'] > 1:
         raise ValueError('Task %d has more than one repeat. This benchmark '
                          'can only work with a single repeat.' % task_id)
 


### PR DESCRIPTION
To make the test for multiple repeats and folds a bit easier to comprehend, the datamanager now inspects the openml.task object directly for these properties rather than trying to get the indices for the second fold/repeat and checking if it fails.