### PR TITLE
Classic control benchmark

### DIFF
--- a/hpolib/benchmarks/rl/classic_control.py
+++ b/hpolib/benchmarks/rl/classic_control.py
@@ -125,12 +125,13 @@ class ClassicControlBase(AbstractBenchmark):
             terminated_episodes.append(np.sum(runner.episode_rewards) / self.max_episodes)
             leftover_episodes = self.max_episodes - runner.global_episode
             if leftover_episodes > 0:  # converged
-                converged_value = np.mean(runner.episode_rewards[-self.avg_n_episodes:])
-                terminated_episodes[-1] += leftover_episodes / self.max_episodes * converged_value
+                converged_reward = max(np.mean(runner.episode_rewards[-self.avg_n_episodes:]), self._reward_threshold())
+                terminated_episodes[-1] += leftover_episodes / self.max_episodes * converged_reward
 
         cost = time.time() - st
 
-        return {'function_value': np.mean(terminated_episodes), "cost": cost, "all_runs": terminated_episodes}
+        negative_mean_reward = -np.mean(terminated_episodes)  # minimization task
+        return {'function_value': negative_mean_reward, "cost": cost, "all_runs": terminated_episodes}
 
     def _on_episode_finished(self, runner, worker_id):
         if runner.global_episode % 10 == 0:

--- a/hpolib/benchmarks/rl/classic_control.py
+++ b/hpolib/benchmarks/rl/classic_control.py
@@ -12,7 +12,10 @@ try:
 except ImportError:
     raise ImportError(
         "Missing tensorforce dependency. "
-        "Install extra 'rl': pip install hpolib2[rl].")
+        "Install extra 'rl': pip install hpolib2[rl]==0.0.1 .")
+
+
+__version__ = "0.2"
 
 
 class ClassicControlBase(AbstractBenchmark):
@@ -184,7 +187,14 @@ class ClassicControlBase(AbstractBenchmark):
     @staticmethod
     def get_meta_information():
         return {'name': 'ClassicControl with PPO',
-                'references': []
+                'references': [],
+                'note': ("Version 0.2:\n"
+                         "- Predefine reward thresholds of convergence criteria for the particular environment\n"
+                         "- Use max episode timesteps predefined by the particular environment\n"
+                         "- Use mean of episode rewards as run performance\n"
+                         "- Log mean performance every 10th episode\n"
+                         "- Command line interface for running default configuration\n"
+                         "- Stop at maximum episodes OR maximum timesteps")
                 }
 
 
@@ -250,20 +260,3 @@ class ClassicControlReduced(ClassicControlBase):
         cs.add_hyperparameter(CS.UniformFloatHyperparameter(
             "entropy_regularization", lower=0, default_value=0.01, upper=1))
         return cs
-
-
-# Allow simple runs via the command line for testing and exploring the benchmark
-if __name__ == '__main__':
-    import argparse
-
-    parser = argparse.ArgumentParser(description='Run a default configuration on classic control benchmark.')
-    parser.add_argument('--env', default="CartPole-v1", help='Open AI gym classic control id.')
-    parser.add_argument('--budget', type=int, default=1, help='Number of repetitions of a configuration.')
-    args = parser.parse_args()
-
-    benchmark = ClassicControlReduced(env=args.env, max_budget=args.budget)
-    benchmark.logger.setLevel(logging.INFO)
-    config_space = benchmark.get_configuration_space()
-    config = config_space.get_default_configuration()
-    result = benchmark.objective_function(config)
-    benchmark.logger.info(result)

--- a/hpolib/benchmarks/rl/classic_control.py
+++ b/hpolib/benchmarks/rl/classic_control.py
@@ -134,10 +134,10 @@ class ClassicControlBase(AbstractBenchmark):
             else:
                 interpolated_leftover_episodes = reward_per_timestep
 
-            if self.max_timesteps and self.max_timesteps > runner.global_timesteps:  # converged, interpolate leftover timesteps
-                leftover_timesteps = self.max_timesteps - runner.global_timesteps
+            if self.max_timesteps and self.max_timesteps > runner.global_timestep:  # converged, interpolate leftover timesteps
+                leftover_timesteps = self.max_timesteps - runner.global_timestep
                 converged_reward = max(np.mean(runner.episode_rewards[-self.avg_n_episodes:]), self._reward_threshold())
-                interpolated_leftover_timesteps = (reward_per_timestep * runner.global_timesteps
+                interpolated_leftover_timesteps = (reward_per_timestep * runner.global_timestep
                                                    + converged_reward * leftover_timesteps) / self.max_timesteps
             else:
                 interpolated_leftover_timesteps = reward_per_timestep

--- a/hpolib/benchmarks/rl/classic_control.py
+++ b/hpolib/benchmarks/rl/classic_control.py
@@ -17,7 +17,7 @@ except ImportError:
 
 class ClassicControlBase(AbstractBenchmark):
     def __init__(self, env="CartPole-v1", rng=None, defaults=None, max_budget=9,
-                 avg_n_episodes=20, max_episodes=3000):
+                 avg_n_episodes=20, max_episodes=3000, max_timesteps=None):
         """
         Parameters
         ----------
@@ -41,6 +41,7 @@ class ClassicControlBase(AbstractBenchmark):
 
         self.env = OpenAIGym(env, visualize=False)
         self.max_episodes = max_episodes
+        self.max_timesteps = max_timesteps
         self.avg_n_episodes = avg_n_episodes
         self.max_budget = max_budget
         self.defaults = {
@@ -120,7 +121,8 @@ class ClassicControlBase(AbstractBenchmark):
             )
 
             runner = Runner(agent=agent, environment=self.env)
-            runner.run(num_episodes=self.max_episodes, episode_finished=self._on_episode_finished)
+            runner.run(num_episodes=self.max_episodes, num_timesteps=self.max_timesteps,
+                       episode_finished=self._on_episode_finished)
 
             terminated_episodes.append(np.sum(runner.episode_rewards) / self.max_episodes)
             leftover_episodes = self.max_episodes - runner.global_episode

--- a/hpolib/benchmarks/rl/classic_control.py
+++ b/hpolib/benchmarks/rl/classic_control.py
@@ -15,7 +15,8 @@ except ImportError:
 
 
 class ClassicControlBase(AbstractBenchmark):
-    def __init__(self, env="CartPole-v1", rng=None, defaults=None, max_budget=9):
+    def __init__(self, env="CartPole-v1", rng=None, defaults=None, max_budget=9,
+                 avg_n_episodes=20, max_episodes=3000):
         """
         Parameters
         ----------
@@ -23,17 +24,23 @@ class ClassicControlBase(AbstractBenchmark):
             set up rng
         defaults: dict
             default configuration used for the PPO agent
+        avg_n_episodes: Optional[int]
+            number of episodes of which average reward is above threshold for convergence
+        max_episodes: int
+            maximum number of episodes to run
         """
 
         super(ClassicControlBase, self).__init__()
 
+        self.logger = logging.getLogger(self.__class__.__name__)
         self.rng = rng_helper.create_rng(rng)
 
-        assert env in ["CartPole-v1", "Acrobot-v1", "MountainCar-v0", "Pendulum-v0", "MountainCarContinuous-v0"]
+        allowed_envs = ["CartPole-v1", "Acrobot-v1", "MountainCar-v0", "Pendulum-v0", "MountainCarContinuous-v0"]
+        assert env in allowed_envs, "Expected env in {}, got {}".format(", ".join(allowed_envs), env)
 
         self.env = OpenAIGym(env, visualize=False)
-        self.max_episodes = 3000
-        self.avg_n_episodes = 20
+        self.max_episodes = max_episodes
+        self.avg_n_episodes = avg_n_episodes
         self.max_budget = max_budget
         self.defaults = {
             "n_units_1": 64,

--- a/hpolib/benchmarks/rl/classic_control.py
+++ b/hpolib/benchmarks/rl/classic_control.py
@@ -201,3 +201,19 @@ class ClassicControlReduced(ClassicControlBase):
         cs.add_hyperparameter(CS.UniformFloatHyperparameter(
             "entropy_regularization", lower=0, default_value=0.01, upper=1))
         return cs
+
+
+# Allow simple runs via the command line for testing and exploring the benchmark
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Run a random configuration on classic control benchmark.')
+    parser.add_argument('--env', default="CartPole-v1", help='Open AI gym classic control id.')
+    parser.add_argument('--budget', type=int, default=1, help='Number of repetitions of a configuration.')
+    args = parser.parse_args()
+
+    benchmark = ClassicControlFull(env=args.env, max_budget=args.budget)
+    config_space = benchmark.get_configuration_space()
+    sample_config = config_space.sample_configuration()
+    result = benchmark.objective_function(sample_config)
+    print(result)

--- a/hpolib/benchmarks/rl/classic_control.py
+++ b/hpolib/benchmarks/rl/classic_control.py
@@ -4,9 +4,14 @@ import ConfigSpace as CS
 import numpy as np
 from hpolib.abstract_benchmark import AbstractBenchmark
 from hpolib.util import rng_helper
-from tensorforce.agents import PPOAgent
-from tensorforce.contrib.openai_gym import OpenAIGym
-from tensorforce.execution import Runner
+try:
+    from tensorforce.agents import PPOAgent
+    from tensorforce.contrib.openai_gym import OpenAIGym
+    from tensorforce.execution import Runner
+except ImportError:
+    raise ImportError(
+        "Missing tensorforce dependency. "
+        "Install extra 'rl': pip install hpolib2[rl].")
 
 
 class ClassicControlBase(AbstractBenchmark):

--- a/hpolib/benchmarks/rl/classic_control.py
+++ b/hpolib/benchmarks/rl/classic_control.py
@@ -7,7 +7,7 @@ from hpolib.abstract_benchmark import AbstractBenchmark
 from hpolib.util import rng_helper
 try:
     from tensorforce.agents import PPOAgent
-    from tensorforce.contrib.openai_gym import OpenAIGym
+    from tensorforce.environments.openai_gym import OpenAIGym
     from tensorforce.execution import Runner
 except ImportError:
     raise ImportError(

--- a/hpolib/benchmarks/rl/classic_control.py
+++ b/hpolib/benchmarks/rl/classic_control.py
@@ -1,4 +1,5 @@
 import time
+import logging
 
 import ConfigSpace as CS
 import numpy as np
@@ -226,7 +227,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     benchmark = ClassicControlFull(env=args.env, max_budget=args.budget)
+    benchmark.logger.setLevel(logging.INFO)
     config_space = benchmark.get_configuration_space()
     sample_config = config_space.sample_configuration()
     result = benchmark.objective_function(sample_config)
-    print(result)
+    benchmark.logger.info(result)

--- a/hpolib/benchmarks/rl/classic_control.py
+++ b/hpolib/benchmarks/rl/classic_control.py
@@ -7,7 +7,7 @@ from hpolib.abstract_benchmark import AbstractBenchmark
 from hpolib.util import rng_helper
 try:
     from tensorforce.agents import PPOAgent
-    from tensorforce.environments.openai_gym import OpenAIGym
+    from tensorforce.contrib.openai_gym import OpenAIGym
     from tensorforce.execution import Runner
 except ImportError:
     raise ImportError(

--- a/hpolib/benchmarks/rl/classic_control.py
+++ b/hpolib/benchmarks/rl/classic_control.py
@@ -234,14 +234,14 @@ class ClassicControlReduced(ClassicControlBase):
 if __name__ == '__main__':
     import argparse
 
-    parser = argparse.ArgumentParser(description='Run a random configuration on classic control benchmark.')
+    parser = argparse.ArgumentParser(description='Run a default configuration on classic control benchmark.')
     parser.add_argument('--env', default="CartPole-v1", help='Open AI gym classic control id.')
     parser.add_argument('--budget', type=int, default=1, help='Number of repetitions of a configuration.')
     args = parser.parse_args()
 
-    benchmark = ClassicControlFull(env=args.env, max_budget=args.budget)
+    benchmark = ClassicControlReduced(env=args.env, max_budget=args.budget)
     benchmark.logger.setLevel(logging.INFO)
     config_space = benchmark.get_configuration_space()
-    sample_config = config_space.sample_configuration()
-    result = benchmark.objective_function(sample_config)
+    config = config_space.get_default_configuration()
+    result = benchmark.objective_function(config)
     benchmark.logger.info(result)

--- a/hpolib/benchmarks/rl/classic_control.py
+++ b/hpolib/benchmarks/rl/classic_control.py
@@ -130,9 +130,9 @@ class ClassicControlBase(AbstractBenchmark):
 
     def _on_episode_finished(self, runner, worker_id):
         if runner.global_episode % 10 == 0:
-            self.logger.info("Finished episode {} at timestep {} with {} reward and {} timesteps"
+            self.logger.info("Finished episode {} at timestep {}. Avg recent episodes: reward {:.1f}, timesteps {:.1f}"
                              .format(runner.global_episode, runner.global_timestep,
-                                     runner.episode_rewards[-1], runner.episode_timesteps[-1]))
+                                     np.mean(runner.episode_rewards[-10:]), np.mean(runner.episode_timesteps[-10:])))
         if self.avg_n_episodes is None:
             converged = False
         else:

--- a/hpolib/benchmarks/rl/classic_control.py
+++ b/hpolib/benchmarks/rl/classic_control.py
@@ -120,8 +120,7 @@ class ClassicControlBase(AbstractBenchmark):
             )
 
             runner = Runner(agent=agent, environment=self.env)
-            runner.run(episodes=self.max_episodes, max_episode_timesteps=200,
-                       episode_finished=self._on_episode_finished)
+            runner.run(episodes=self.max_episodes, episode_finished=self._on_episode_finished)
 
             converged_episodes.append(len(runner.episode_rewards))
 

--- a/hpolib/benchmarks/rl/classic_control.py
+++ b/hpolib/benchmarks/rl/classic_control.py
@@ -138,9 +138,23 @@ class ClassicControlBase(AbstractBenchmark):
             converged = False
         else:
             mean_reward = np.mean(runner.episode_rewards[-self.avg_n_episodes:])
-            reward_threshold = runner.environment.gym.unwrapped.spec.reward_threshold
-            converged = mean_reward >= reward_threshold
+            converged = mean_reward >= self._reward_threshold()
         return not converged
+
+    _fallback_reward_thresholds = {  # according to gym 0.12.5
+        'Acrobot-v1': 500,
+        'Pendulum-v0': 200,
+    }
+
+    def _reward_threshold(self):
+        """ Shim reward thresholds not available
+            in gym==0.9.5 (required by tensorforce)
+        """
+        threshold = self.env.gym.unwrapped.spec.reward_threshold
+        if threshold is None:
+            return self._fallback_reward_thresholds[self.env.gym_id]
+        else:
+            return threshold
 
     @AbstractBenchmark._check_configuration
     def objective_function_test(self, config, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,17 @@
-cython
+configparser
+unittest2
+nose
+setuptools
+
+six
+
 numpy>=1.9.0
 scipy>=0.14.1
 matplotlib
-ConfigSpace>=0.4.0
-configparser
+
+# We need lasagne 0.2dev1 + corresponding theano version
+theano==0.8.2
+git+https://github.com/Lasagne/Lasagne.git@master
+
+scikit-learn
+ConfigSpace>=0.3.3

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=['test']),
     install_requires=['cython', 'numpy>=1.9.0', 'scipy>=0.14.1', 'ConfigSpace>=0.4.0', 'configparser', 'matplotlib'],
     extras_require={
-        'rl': ["tensorforce[tf]", "gym[classic_control]"]
+        'rl': ["tensorforce[tf]==0.5.1", "gym[classic_control]==0.14.0"]
     },
     test_suite='nose.collector',
     scripts=[],

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,9 @@ setuptools.setup(
     version=version,
     packages=setuptools.find_packages(exclude=['test']),
     install_requires=['cython', 'numpy>=1.9.0', 'scipy>=0.14.1', 'ConfigSpace>=0.4.0', 'configparser', 'matplotlib'],
+    extras_require={
+        'rl': ["tensorforce[tf,gym]"]
+    },
     test_suite='nose.collector',
     scripts=[],
     #include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=['test']),
     install_requires=['cython', 'numpy>=1.9.0', 'scipy>=0.14.1', 'ConfigSpace>=0.4.0', 'configparser', 'matplotlib'],
     extras_require={
-        'rl': ["tensorforce[tf,gym]"]
+        'rl': ["tensorforce[tf]", "gym[classic_control]"]
     },
     test_suite='nose.collector',
     scripts=[],

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=['test']),
     install_requires=['cython', 'numpy>=1.9.0', 'scipy>=0.14.1', 'ConfigSpace>=0.4.0', 'configparser', 'matplotlib'],
     extras_require={
-        'rl': ["tensorforce[tf]==0.5.1", "gym[classic_control]==0.14.0"]
+        'rl': ["tensorforce[tf]==0.4.4", "gym[classic_control]==0.14.0"]
     },
     test_suite='nose.collector',
     scripts=[],


### PR DESCRIPTION
Changes:

* Predefine reward thresholds of convergence criteria for the particular environment
* Use max episode timesteps predefined by the particular environment
* Use mean of episode rewards as run performance
* Log mean performance every 10th episode
* Command line interface for running default configuration
* Stop at maximum episodes OR maximum timesteps