### PR TITLE
Autosklearn can make use of a tmpdir

### DIFF
--- a/hpolib/benchmarks/ml/autosklearn_benchmark.py
+++ b/hpolib/benchmarks/ml/autosklearn_benchmark.py
@@ -25,6 +25,15 @@ import hpolib
 __version__ = 0.3
 
 
+class NoFileSavingBackend(autosklearn.util.backend.Backend):
+
+    def save_datamanager(self, datamanager):
+        self.datamanager = datamanager
+
+    def load_datamanager(self):
+        return self.datamanager
+
+
 class AutoSklearnBenchmark(AbstractBenchmark):
     """Base class for auto-sklearn benchmarks.
 
@@ -73,11 +82,15 @@ class AutoSklearnBenchmark(AbstractBenchmark):
     def _setup_backend(self):
         tmp_folder = os.path.join(self._tmpdir, 'tmp')
         output_folder = os.path.join(self._tmpdir, 'out')
-        self.backend = autosklearn.util.backend.create(
+
+        context = autosklearn.util.backend.BackendContext(
             temporary_directory=tmp_folder,
             output_directory=output_folder,
             delete_tmp_folder_after_terminate=True,
-            delete_output_folder_after_terminate=True)
+            delete_output_folder_after_terminate=True,
+            shared_mode=False)
+        self.backend = NoFileSavingBackend(context)
+
         self.backend.save_datamanager(self.data_manager)
         self.logger = logging.getLogger(self.__class__.__name__)
 

--- a/hpolib/benchmarks/ml/autosklearn_benchmark.py
+++ b/hpolib/benchmarks/ml/autosklearn_benchmark.py
@@ -25,15 +25,6 @@ import hpolib
 __version__ = 0.3
 
 
-class NoFileSavingBackend(autosklearn.util.backend.Backend):
-
-    def save_datamanager(self, datamanager):
-        self.datamanager = datamanager
-
-    def load_datamanager(self):
-        return self.datamanager
-
-
 class AutoSklearnBenchmark(AbstractBenchmark):
     """Base class for auto-sklearn benchmarks.
 
@@ -82,15 +73,11 @@ class AutoSklearnBenchmark(AbstractBenchmark):
     def _setup_backend(self):
         tmp_folder = os.path.join(self._tmpdir, 'tmp')
         output_folder = os.path.join(self._tmpdir, 'out')
-
-        context = autosklearn.util.backend.BackendContext(
+        self.backend = autosklearn.util.backend.create(
             temporary_directory=tmp_folder,
             output_directory=output_folder,
             delete_tmp_folder_after_terminate=True,
-            delete_output_folder_after_terminate=True,
-            shared_mode=False)
-        self.backend = NoFileSavingBackend(context)
-
+            delete_output_folder_after_terminate=True)
         self.backend.save_datamanager(self.data_manager)
         self.logger = logging.getLogger(self.__class__.__name__)
 

--- a/hpolib/benchmarks/ml/autosklearn_benchmark.py
+++ b/hpolib/benchmarks/ml/autosklearn_benchmark.py
@@ -43,11 +43,15 @@ class AutoSklearnBenchmark(AbstractBenchmark):
         instances.
     """
 
-    def __init__(self, task_id, resampling_strategy='partial-cv', rng=None):
+    def __init__(self, task_id, resampling_strategy='partial-cv', tmpdir=None, rng=None):
 
         self._check_dependencies()
         self._get_data_manager(task_id)
-        self._tmpdir = tempfile.mkdtemp()
+
+        if tmpdir is None:
+            self._tmpdir = tempfile.mkdtemp()
+        else:
+            self._tmpdir = tmpdir
         self._setup_backend()
 
         # Setup of the datamanager etc has to be done before call to super
@@ -404,8 +408,8 @@ class FBIS_WC(MulticlassClassificationBenchmark):
 for task_id in get_openml100_taskids():
     benchmark_string = """class OpenML100_%d(MulticlassClassificationBenchmark):
 
-     def __init__(self, resampling_strategy='partial-cv', rng=None):
-         super().__init__(%d, resampling_strategy=resampling_strategy, rng=rng)
+     def __init__(self, resampling_strategy='partial-cv', tmpdir=None, rng=None):
+         super().__init__(%d, resampling_strategy=resampling_strategy, tmpdir=tmpdir, rng=rng)
 """ % (task_id, task_id)
 
     exec(benchmark_string)
@@ -413,8 +417,8 @@ for task_id in get_openml100_taskids():
 for task_id in get_openmlcc18_taskids():
     benchmark_string = """class OpenMLCC18_%d(MulticlassClassificationBenchmark):
 
-     def __init__(self, resampling_strategy='partial-cv', rng=None):
-         super().__init__(%d, resampling_strategy=resampling_strategy, rng=rng)
+     def __init__(self, resampling_strategy='partial-cv', tmpdir=None, rng=None):
+         super().__init__(%d, resampling_strategy=resampling_strategy, tmpdir=tmpdir, rng=rng)
 """ % (task_id, task_id)
 
     exec(benchmark_string)


### PR DESCRIPTION
I think for our case it is fine to have the data always in memory. We do the same in all other benchmarks.

Additionally, this avoids remaining files after killing auto-sklearn using the runsolver.