### PR TITLE
fix exploring openml xgb benchmark

### DIFF
--- a/hpolib/benchmarks/surrogates/exploring_openml.py
+++ b/hpolib/benchmarks/surrogates/exploring_openml.py
@@ -33,6 +33,211 @@ from hpolib.abstract_benchmark import AbstractBenchmark
 __version__ = 0.2
 
 
+# Differences to the paper are in comments at the end of the line
+_expected_amount_of_data = {
+    'GLMNET': {
+        3: 15546,  # Paper says that there are 15547 entries, but one of them has a negative runtime
+        31: 15528,  # Paper says that there are 15547 entries, but 19 of them have a negative runtime
+        37: 15488,  # Paper says that there are 15546 entries, but 58 of them have a negative runtime
+        44: 15527,  # Paper says that there are 15547 entries, but 20 of them have a negative runtime
+        50: 15545,  # Paper says that there are 15547 entries, but 2 of them have a negative runtime
+        151: 15547,
+        312: 6613,
+        333: 15441,  # Paper says that there are 15547 entries, but 105 of them have a negative runtime
+        334: 15486,  # Paper says that there are 15547 entries, but 61 of them have a negative runtime
+        335: 15516,  # Paper says that there are 15547 entries, but 31 of them have a negative runtime
+        1036: 14937,
+        1038: 15547,
+        1043: 6365,  # Paper says that there are 6466 entries, but 101 of them have a negative runtime
+        1046: 15462,
+        1049: 7396,  # Paper says that there are 7423 entries, but 27 of them have a negative runtime
+        1050: 15521,  # Paper says that there are 15521 entries, but 26 of them have a negative runtime
+        1063: 15518,  # Paper says that there are 15518 entries, but 29 of them have a negative runtime
+        1067: 15523,  # Paper says that there are 15518 entries, but 23 of them have a negative runtime
+        1068: 15546,
+        1120: 15531,
+        1176: 13005,  # Paper does not mention this dataset
+        1461: 6970,
+        1462: 8955,
+        1464: 15531, # Paper says that there are 15518 entries, but 16 of them have a negative runtime
+        1467: 15387, # Paper says that there are 15518 entries, but 160 of them have a negative runtime
+        1471: 15479,  # Paper says that there are 15518 entries, but 68 of them have a negative runtime
+        1479: 15546,
+        1480: 15000,  # Paper says that there are 15518 entries, but 24 of them have a negative runtime
+        1485: 8247,
+        1486: 3866,
+        1487: 15543,  # Paper says that there are 15518 entries, but 4 of them have a negative runtime
+        1489: 15522,  # Paper says that there are 15518 entries, but 25 of them have a negative runtime
+        1494: 15515,  # Paper says that there are 15518 entries, but 15 of them have a negative runtime
+        1504: 15527,  # Paper says that there are 15518 entries, but 20 of them have a negative runtime
+        1510: 15406,  # Paper says that there are 15518 entries, but 141 of them have a negative runtime
+        1570: 15452,  # Paper says that there are 15518 entries, but 94 of them have a negative runtime
+        4134: 1493,
+        4534: 2801,
+    },
+    'RPART': {
+        3: 14624,  # Paper says that there are 14633 entries, but 9 of them have a negative runtime
+        31: 14624,  # Paper says that there are 14633 entries, but 9 of them have a negative runtime
+        37: 14598,  # Paper says that there are 14633 entries, but 35 of them have a negative runtime
+        44: 14633,
+        50: 14618,  # Paper says that there are 14633 entries, but 15 of them have a negative runtime
+        151: 14632,
+        312: 13455,
+        333: 14585,  # Paper says that there are 14633 entries, but 47 of them have a negative runtime
+        334: 14580,  # Paper says that there are 14633 entries, but 53 of them have a negative runtime
+        335: 14625,  # Paper says that there are 14633 entries, but 8 of them have a negative runtime
+        1036: 14633,
+        1038: 5151,
+        1043: 14633,
+        1046: 14624,  # Paper says that there are 14633 entries, but 8 of them have a negative runtime
+        1049: 14549,  # Paper says that there are 14633 entries, but 83 of them have a negative runtime
+        1050: 14497,  # Paper says that there are 14633 entries, but 136 of them have a negative runtime
+        1063: 14497,  # Paper says that there are 14633 entries, but 136 of them have a negative runtime
+        1067: 14632,
+        1068: 14633,
+        1120: 7477,
+        1176: 14632,  # Paper does not mention this dataset
+        1461: 14073,
+        1462: 14536,  # Paper says that there are 14633 entries, but 97 of them have a negative runtime
+        1464: 14609,  # Paper says that there are 14633 entries, but 23 of them have a negative runtime
+        1467: 14626,  # Paper says that there are 14633 entries, but 7 of them have a negative runtime
+        1471: 14616,  # Paper says that there are 14633 entries, but 17 of them have a negative runtime
+        1479: 14633,
+        1480: 14576,  # Paper says that there are 14633 entries, but 57 of them have a negative runtime
+        1485: 10923,
+        1486: 11389,
+        1487: 6005,
+        1489: 14628,  # Paper says that there are 14633 entries, but 5 of them have a negative runtime
+        1494: 14632,
+        1504: 14629,  # Paper says that there are 14633 entries, but 4 of them have a negative runtime
+        1510: 14561,  # Paper says that there are 14633 entries, but 72 of them have a negative runtime
+        1570: 14515,  # Paper says that there are 14633 entries, but 117 of them have a negative runtime
+        4134: 3947,
+        4534: 3231,
+    },
+    'SVM': {
+        3: 19644,
+        31: 19644,
+        37: 15985,
+        44: 19644,
+        50: 19644,
+        151: 2384,
+        312: 18740,
+        333: 19634,  # Paper says that there are 19644 entries, but 10 of them have a negative runtime
+        334: 19629,  # Paper says that there are 19644 entries, but 15 of them have a negative runtime
+        335: 15123,
+        1036: 2338,
+        1038: 5716,
+        1043: 10121,
+        1046: 5422,
+        1049: 12064,
+        1050: 19644,
+        1063: 19644,
+        1067: 10229,
+        1068: 13893,
+        1120: 3908,
+        1176: 14451,  # Paper does not mention this dataset
+        1461: 2678,
+        1462: 6320,
+        1464: 19644,
+        1467: 4441,
+        1471: 9725,
+        1479: 19644,
+        1480: 19644,
+        1485: 10334,
+        1486: 1490,
+        1487: 19644,
+        1489: 17298,
+        1494: 19644,
+        1504: 19644,
+        1510: 19644,
+        1570: 19644,
+        4134: 560,
+        4534: 2476,
+    },
+    'Ranger': {
+        3: 15135,  # Paper says 15139, but for 4 instances min.node.size > 1
+        31: 14965,  # Paper says 15139, but for 158 instances min.node.size > 1 and for 16 instances mtry > 1
+        37: 15060,  # Paper says 15139, but for 79 instances min.node.size > 1
+        44: 15129,  # Paper says 15139, but for 79 instances min.node.size > 1
+        50: 13357,  # Paper says 15139, but for 219 instances min.node.size > 1 and for 219 instances mtry > 1563
+        151: 12381,  # Paper says 12517, but for 136 instances mtry > 1
+        312: 12937,  # Paper says 12985, but for 48 instances min.node.size > 1
+        333: 15066,  # Paper says 15139, but for 73 instances min.node.size > 1
+        334: 14441,  # Paper says 14492, but for 51 instances min.node.size > 1
+        335: 14295,  # Paper says 15139, but for 299 instances min.node.size > 1 and for 219 instances mtry > 545
+        1036: 7394,  # Paper says 15139, but for 3 instances min.node.size > 1
+        1038: 4827,
+        1043: 3788,
+        1046: 8838,  # Paper says 8842, but for 4 instances min.node.size > 1
+        1049: 14819,  # Paper says 15139, but for 320 instances min.node.size > 1
+        1050: 11328,  # Paper says 11357, but for 29 instances min.node.size > 1
+        1063: 7883,  # Paper says 7914, but for 29 instances min.node.size > 1
+        1067: 7364,  # Paper says 7386, but for 22 instances min.node.size > 1
+        1068: 8135,  # Paper says 8173, but for 38 instances min.node.size > 1
+        1120: 9760,
+        1176: 15117,  # Paper does not mention this dataset
+        1461: 14279,  # Paper says 14323, but for 44 instances mtry > 1
+        1462: 15103,  # Paper says 15139, but for 36 instances min.node.size > 1
+        1464: 15034,  # Paper says 15139, but for 105 instances min.node.size > 1
+        1467: 14896,  # Paper says 15139, but for 243 instances min.node.size > 1
+        1471: 13522,  # Paper says 13523, but for 1 instances min.node.size > 1
+        1479: 15092,  # Paper says 15140, but for 48 instances min.node.size > 1
+        1480: 15074,  # Paper says 15139, but for 65 instances min.node.size > 1
+        1485: 15015,  # Paper says 15139, but for 124 instances min.node.size > 1
+        1486: 15139,
+        1487: 15108,  # Paper says 15139, but for 31 instances min.node.size > 1
+        1489: 15137,  # Paper says 15139, but for 2 instances min.node.size > 1
+        1494: 14807,  # Paper says 15139, but for 332 instances min.node.size > 1
+        1504: 14938,  # Paper says 15140, but for 202 instances min.node.size > 1
+        1510: 15071,  # Paper says 15139, but for 68 instances min.node.size > 1
+        1570: 15136,  # Paper says 15139, but for 3 instances min.node.size > 1
+        4134: 14472,  # Paper says 14516, but for 44 instances min.node.size > 1
+        4534: 15129,  # Paper says 14516, but for 10 instances min.node.size > 1
+    },
+    'XGBoost': {
+        3: 16867,
+        31: 16867,
+        37: 16866,
+        44: 16867,
+        50: 16866,
+        151: 16272,  # should be 16866, but eta, colsample_by_tree and colsample_by_level sometimes missing
+        312: 15886,
+        333: 16865,  # should be 16867, but 2 samples have negative runtime
+        334: 16866,  # should be 16867, but 1 sample has a negative runtime
+        335: 10002,
+        1036: 2581,
+        1038: 1370,
+        1043: 16867,
+        1046: 11812,
+        1049: 4453,
+        1050: 13758,
+        1063: 16865,  # should be 16866, but 1 sample has a negative runtime
+        1067: 16866,
+        1068: 16866,
+        1120: 8143,
+        1176: 13047,  # Paper does not mention this dataset
+        1461: 2215,
+        1462: 16859,  # should be 16867, but 8 sample have a negative runtime
+        1464: 16865,  # should be 16867, but 2 sample have a negative runtime
+        1467: 16865,  # should be 16866, but 1 sample has a negative runtime
+        1471: 16866,
+        1479: 16867,
+        1480: 16254,
+        1485: 9237,
+        1486: 5813,
+        1487: 11194,
+        1489: 16867,
+        1494: 16867,
+        1504: 16867,
+        1510: 16867,
+        1570: 16866,  # should be 16867, but 1 sample has a negative runtime
+        4134: 2222,
+        4534: 947,
+    },
+}
+
+
 class ExploringOpenML(AbstractBenchmark):
     """Surrogate benchmarks based on the data from Automatic Exploration of Machine Learning
     Benchmarks on OpenML by Kühn et al..
@@ -230,6 +435,17 @@ class ExploringOpenML(AbstractBenchmark):
         runtimes = np.array(runtimes) + 1e-10
         features = self.impute(features)
         self.logger.info('Finished reading in surrogate data.')
+
+        if len(configurations) != _expected_amount_of_data[self.classifier][dataset_id]:
+            raise ValueError(
+                'Expected %d configurations for classifier %s on dataset %d, but found only %d!' %
+                (
+                    _expected_amount_of_data[self.classifier][dataset_id],
+                    self.classifier,
+                    self.dataset_id,
+                    len(configurations),
+                )
+            )
 
         self.configurations = configurations
         self.features = features

--- a/hpolib/benchmarks/surrogates/exploring_openml.py
+++ b/hpolib/benchmarks/surrogates/exploring_openml.py
@@ -30,7 +30,7 @@ import hpolib
 from hpolib.abstract_benchmark import AbstractBenchmark
 
 
-__version__ = 0.1
+__version__ = 0.2
 
 
 class ExploringOpenML(AbstractBenchmark):
@@ -190,12 +190,12 @@ class ExploringOpenML(AbstractBenchmark):
                     # default and the OpenML R package did not upload the
                     # default in one of the earliest versions
                     continue
-                elif 'colsample_bytree' not in config:
+                elif 'colsample_bytree' not in config and config['booster'] == 'gbtree':
                     # MF: according to Philipp, the algorithm was run in the
                     # default and the OpenML R package did not upload the
                     # default in one of the earliest versions
                     continue
-                elif 'colsample_bylevel' not in config:
+                elif 'colsample_bylevel' not in config and config['booster'] == 'gbtree':
                     # MF: according to Philipp, the algorithm was run in the
                     # default and the OpenML R package did not upload the
                     # default in one of the earliest versions


### PR DESCRIPTION
Previously, samples for the XGB benchmark which had the booster set to `gblinear` were mistakenly discarded. This PR fixes this and introduces strict checks on the number of instances loaded.